### PR TITLE
chore: update staging workflow

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -42,6 +42,9 @@ jobs:
     needs: staging-deploy
     if: ${{ github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -49,11 +52,10 @@ jobs:
         id: properties
         run: echo "version=$(date +'%Y.%m.%d%H%M')" >> $GITHUB_OUTPUT
       - name: Create release
-        uses: actions/create-release@v1
+        uses: softprops/action-gh-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: v${{ steps.properties.outputs.version }}
-          release_name: v${{ steps.properties.outputs.version }}
           body: 'New release'
           draft: true


### PR DESCRIPTION
Replace `actions/create-release` with `softprops/action-gh-release` because the former is no longer maintained and causes some warnings.